### PR TITLE
図の描画部分を追加・ベンチマーク部分のリファクタの実行

### DIFF
--- a/benchmark/check.py
+++ b/benchmark/check.py
@@ -16,11 +16,11 @@ def evaluate():
     model = ModelFileFactory(filename).create()
     evaluator = ModelEvaluator(model)
     benchmark = Benchmark()
-    result_dic = benchmark.run(evaluator)
+    result_lists = benchmark.run(evaluator)
 
-    for key, result in result_dic.items():
-        print(key)
-        result.print()
+    for result_list in result_lists:
+        result_list.print()
+        result_list.show_failed()
 
 if __name__ == "__main__":
     evaluate()

--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -1,3 +1,4 @@
 numpy==1.23.5
 pytest==7.3.1
 pillow==9.5.0
+graphviz==0.20.1

--- a/src/applications/make_search_tree.py
+++ b/src/applications/make_search_tree.py
@@ -1,0 +1,9 @@
+from src.domains.runner.serach_tree_runner import SearchTreeRunner
+from src.domains.shogi.shogi_state import ShogiState
+
+def make_search_tree(model_filename: str):
+    runner = SearchTreeRunner.create_best(model_filename)
+    runner.run(ShogiState.create_initial(), 3)
+    node = runner.get_node()
+
+    print(node)

--- a/src/applications/make_search_tree.py
+++ b/src/applications/make_search_tree.py
@@ -1,9 +1,10 @@
 from src.domains.runner.serach_tree_runner import SearchTreeRunner
 from src.domains.shogi.shogi_state import ShogiState
+from src.domains.shogi.visualizers.graph import Graph
 
 def make_search_tree(model_filename: str):
     runner = SearchTreeRunner.create_best(model_filename)
-    runner.run(ShogiState.create_initial(), 3)
+    runner.run(ShogiState.create_initial(), 2)
     node = runner.get_node()
 
-    print(node)
+    Graph(node).show()

--- a/src/applications/test.py
+++ b/src/applications/test.py
@@ -4,7 +4,7 @@ from src.consts.application import Winner
 
 def test():
     runner = HistoryRunner.create_mcts()
-    runner.run(ShogiState.create_initial(), 0)
+    runner.run(ShogiState.create_initial())
     winner = runner.get_winner()
     history = runner.get_history()
 

--- a/src/applications/test_with_model.py
+++ b/src/applications/test_with_model.py
@@ -4,7 +4,7 @@ from src.consts.application import Winner
 
 def test_with_model(model_filename: str):
     runner = HistoryRunner.create_best(model_filename)
-    runner.run(ShogiState.create_initial())
+    runner.run(ShogiState.from_key('0603001200aa010100'))
     winner = runner.get_winner()
     history = runner.get_history()
 
@@ -15,4 +15,5 @@ def test_with_model(model_filename: str):
     else:
         print("draw")
 
-    history.print()
+    gif = history.create_gif()
+    gif.show()

--- a/src/applications/test_with_model.py
+++ b/src/applications/test_with_model.py
@@ -4,7 +4,7 @@ from src.consts.application import Winner
 
 def test_with_model(model_filename: str):
     runner = HistoryRunner.create_best(model_filename)
-    runner.run(ShogiState.create_initial(), 0)
+    runner.run(ShogiState.create_initial())
     winner = runner.get_winner()
     history = runner.get_history()
 

--- a/src/applications/train.py
+++ b/src/applications/train.py
@@ -6,7 +6,7 @@ TRIAL = 1000
 def train():
     runner = TrainDataStrategyFactoryRunner.create_mcts()
     for _ in range(TRIAL):
-        runner.run(ShogiState.create_initial(), 0)
+        runner.run(ShogiState.create_initial())
     train_data = runner.get_factory().create()
     print(train_data)
     train_data.save()

--- a/src/applications/train_multi.py
+++ b/src/applications/train_multi.py
@@ -8,7 +8,7 @@ def train_multi(trial: int, seed: int, filename: str):
     runner = TrainDataStrategyFactoryRunner.create_mcts()
     runner.set_seed(seed)
     for _ in range(trial):
-        runner.run(ShogiState.from_key(base_key), 0)
+        runner.run(ShogiState.from_key(base_key))
     train_data = runner.get_factory().create()
     print(f"試合回数: {trial}")
     print(f"総出現局面数: {train_data.get_size()}")

--- a/src/applications/train_multi_model.py
+++ b/src/applications/train_multi_model.py
@@ -8,7 +8,7 @@ def train_multi_model(trial: int, seed: int, filename: str, model_name: str):
     runner = TrainDataStrategyFactoryRunner.create_with_model(model_name)
     runner.set_seed(seed)
     for _ in range(trial):
-        runner.run(ShogiState.from_key(base_key), 0)
+        runner.run(ShogiState.from_key(base_key))
     train_data = runner.get_factory().create()
     print(f"試合回数: {trial}")
     print(f"総出現局面数: {train_data.get_size()}")

--- a/src/consts/application.py
+++ b/src/consts/application.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 Step = int
+Deps = int
 DRAW_LIMIT = 100
 
 class Winner(Enum):

--- a/src/domains/abstract/pick_state_strategy.py
+++ b/src/domains/abstract/pick_state_strategy.py
@@ -12,3 +12,7 @@ class PickStateStrategy(ABC):
     @abstractmethod
     def pick_state_verbose(self, original_state: State, next_states: List[State], data: Dict[Key, List[Score]]) -> Tuple[State, Score, SelectionProbability]:
         pass
+
+    @abstractmethod
+    def get_all_verbose(self, original_state: State, next_states: List[State], data: Dict[Key, List[Score]]) -> List[Tuple[State, Score, SelectionProbability]]:
+        pass

--- a/src/domains/benchmark/benchmark.py
+++ b/src/domains/benchmark/benchmark.py
@@ -2,8 +2,7 @@ from typing import Dict, List
 import json
 from src.domains.abstract.evaluator import Evaluator
 from src.domains.benchmark.benchmark_data import BenchmarkData
-from src.domains.benchmark.benchmark_result import BenchmarkResult
-from src.domains.shogi.shogi_state import ShogiState
+from src.domains.benchmark.benchmark_result_list import BenchmarkResultList
 
 DATA = "data"
 CHECKMATE = "詰み"
@@ -39,15 +38,9 @@ class Benchmark():
                     return False
         return True
         
-    def run(self, evaluator: Evaluator) -> Dict[str, BenchmarkResult]:
-        dic: Dict[str, BenchmarkResult] = {}
+    def run(self, evaluator: Evaluator) -> List[BenchmarkResultList]:
+        list: List[BenchmarkResultList] = []
         for key, datas in self.data.items():
-            succeed: List[BenchmarkData] = []
-            failed: List[BenchmarkData] = []
-            for data in datas:
-                if data.check(evaluator):
-                    succeed.append(data)
-                else:
-                    failed.append(data)
-            dic[key] = BenchmarkResult(succeed, failed)
-        return dic
+            results = [data.check(evaluator) for data in datas]
+            list.append(BenchmarkResultList(key, results))
+        return list

--- a/src/domains/benchmark/benchmark_data.py
+++ b/src/domains/benchmark/benchmark_data.py
@@ -1,21 +1,19 @@
-from typing import List
+from typing import List, Union
 from src.consts.domain import Key, Score
 from src.domains.abstract.evaluator import Evaluator
+from src.domains.benchmark.benchmark_result import BenchmarkResult
 from src.domains.shogi.shogi_state import ShogiState
-
 
 class BenchmarkData:
     def __init__(self, x: Key, ys: List[Key]):
         self.x = x
         self.ys = ys
+        self.answer: Union[Key, None] = None
 
-    def check(self, evaluator: Evaluator) -> bool:
+    def check(self, evaluator: Evaluator) -> BenchmarkResult:
         states = ShogiState.from_key(self.x).get_next_states()
-        state = max(states, key=lambda state: -1 * self.evaluate(state.get_unique_key(), evaluator))
-        for y in self.ys:
-            if y == state.get_unique_key():
-                return True
-        return False
+        answer = max(states, key=lambda state: -1 * self.evaluate(state.get_unique_key(), evaluator)).get_unique_key()
+        return BenchmarkResult(self.x, answer, self.ys, answer in self.ys)
 
     def test(self) -> bool:
         keys = [state.get_unique_key() for state in ShogiState.from_key(self.x).get_next_states()]
@@ -28,6 +26,3 @@ class BenchmarkData:
 
     def evaluate(self, key: Key, evaluator: Evaluator) -> Score:
         return evaluator.search_score(key)
-    
-    def print(self) -> None:
-        print(f"x_key: {self.x}")

--- a/src/domains/benchmark/benchmark_result.py
+++ b/src/domains/benchmark/benchmark_result.py
@@ -1,11 +1,25 @@
 from typing import List
-from src.domains.benchmark.benchmark_data import BenchmarkData
+from src.consts.domain import Key
+from src.domains.shogi.shogi_state import ShogiState
+from src.domains.shogi.visualizers.gif import Gif
+from src.domains.shogi.visualizers.image import Image
+from src.domains.shogi.visualizers.image_visualizer import ImageVisualizer
 
 class BenchmarkResult:
-    def __init__(self, succeed_datas: List[BenchmarkData], failed_datas: List[BenchmarkData]) -> None:
-        self.succeed_datas = succeed_datas
-        self.failed_datas = failed_datas
+    def __init__(self, x: Key, answer: Key, ys: List[Key], succeeded: bool) -> None:
+        self.x = x
+        self.answer = answer
+        self.ys = ys
+        self.succeeded = succeeded
 
-    def print(self):
-        print('succeed: ' + str(len(self.succeed_datas)))
-        print('failed: ' + str(len(self.failed_datas)))
+    def is_succeeded(self) -> bool:
+        return self.succeeded
+    
+    def show(self) -> None:
+        images = [self._get_image(self.x), self._get_image(self.answer, True), self._get_image(self.ys[0], True)]
+        gif = Gif(images)
+        gif.show()
+
+    def _get_image(self, key: Key, should_turn: bool = False) -> Image:
+        state = ShogiState.from_key(key)
+        return ImageVisualizer(state, should_turn).visualize()

--- a/src/domains/benchmark/benchmark_result_list.py
+++ b/src/domains/benchmark/benchmark_result_list.py
@@ -1,0 +1,26 @@
+from typing import List
+from src.domains.benchmark.benchmark_result import BenchmarkResult
+
+class BenchmarkResultList:
+    def __init__(self, key: str, results: List[BenchmarkResult]) -> None:
+        self.key = key
+        self.results = results
+
+    def print(self) -> None:
+        succeed_count = 0
+        failed_count = 0
+        for result in self.results:
+            if result.is_succeeded():
+                succeed_count += 1
+            else:
+                failed_count += 1
+        print(self.key)
+        print('succeed: ' + str(succeed_count))
+        print('failed: ' + str(failed_count))
+
+    def show_failed(self) -> None:
+        for result in self.results:
+            if result.is_succeeded():
+                continue
+            else:
+                result.show()

--- a/src/domains/runner/history_runner.py
+++ b/src/domains/runner/history_runner.py
@@ -41,7 +41,10 @@ class HistoryRunner():
         self.strategy = strategy
         self.winner: Union[None, Winner] = None
 
-    def run(self, state: State, step: Step, probability: SelectionProbability = 1):
+    def run(self, state: State) -> None:
+        self._run(state, 0, 1)
+    
+    def _run(self, state: State, step: Step, probability: SelectionProbability):
         # ループからの離脱
         if step > DRAW_LIMIT: return 0
 
@@ -63,7 +66,7 @@ class HistoryRunner():
         # 再帰
         next_states = state.get_next_states()
         next_state, score, new_probability = self.strategy.pick_state_verbose(state, next_states, {})
-        self.run(next_state, step + 1, new_probability)
+        self._run(next_state, step + 1, new_probability)
 
         # フィードバック
         self.history.data_add(state, score * -1, probability)

--- a/src/domains/runner/serach_tree_runner.py
+++ b/src/domains/runner/serach_tree_runner.py
@@ -1,0 +1,71 @@
+import numpy as np
+from typing import Union
+from src.consts.application import Deps
+from src.consts.domain import Finish
+from src.domains.abstract.pick_state_strategy import PickStateStrategy
+from src.domains.abstract.state import State
+from src.domains.model.model_evaluator import ModelEvaluator
+from src.domains.model.model_file_factory import ModelFileFactory
+from src.domains.shogi.search_tree_node import SearchTreeNode
+from src.domains.strategy.pick_state_best_strategy import PickStateBestStrategy
+from src.domains.strategy.pick_state_randomly_strategy import PickStateRandomlyStrategy
+from src.domains.strategy.pick_state_softmax_strategy import PickStateSoftmaxStrategy
+
+# 探索を行う木の作成
+class SearchTreeRunner():
+    # モデルを利用してSoftmax + (UCB)のRunnerを作成する
+    @staticmethod
+    def create_with_model(model_filename: str, use_ucb: bool = False) -> 'SearchTreeRunner':
+        model = ModelFileFactory(model_filename).create()
+        strategy = PickStateSoftmaxStrategy(ModelEvaluator(model), use_ucb)
+        return SearchTreeRunner(strategy)
+    
+    # MCTsによるランダム試行のRunnerを作成する
+    @staticmethod
+    def create_mcts() -> 'SearchTreeRunner':
+        strategy = PickStateRandomlyStrategy()
+        return SearchTreeRunner(strategy)
+    
+    # 最善を選択する(実質的にmctsと同じになる)
+    @staticmethod
+    def create_best(model_filename: str) -> 'SearchTreeRunner':
+        model = ModelFileFactory(model_filename).create()
+        strategy = PickStateBestStrategy(ModelEvaluator(model))
+        return SearchTreeRunner(strategy)
+    
+    def set_seed(self, seed: int) -> None:
+        np.random.seed(seed)
+
+    def __init__(self, strategy: PickStateStrategy):
+        self.strategy = strategy
+        self.node: Union[None, SearchTreeNode] = None
+
+    def run(self, state: State, deps: Deps):
+        node = SearchTreeNode(state, 0, 1)
+        self._run(node, deps)
+        self.node = node
+
+    # 深さ優先探索
+    def _run(self, node: SearchTreeNode, deps: Deps):
+        # ループからの離脱
+        if deps < 1:
+            return
+
+        state = node.get_state()
+        # 終了判定
+        finish = state.get_finish()
+        if finish != Finish.NOT:
+            return
+
+        # 再帰
+        next_states = state.get_next_states()
+        datas = self.strategy.get_all_verbose(state, next_states, {})
+        for (next_state, score, new_probability) in datas:
+            node.data_add(next_state, score, new_probability)
+        
+        nodes = node.get_children()
+        for new_node in nodes:
+            self._run(new_node, deps - 1)
+
+    def get_node(self) -> SearchTreeNode:
+        return self.node

--- a/src/domains/runner/train_data_strategy_factory_runner.py
+++ b/src/domains/runner/train_data_strategy_factory_runner.py
@@ -29,8 +29,11 @@ class TrainDataStrategyFactoryRunner():
 
     def set_seed(self, seed: int) -> None:
         np.random.seed(seed)
+
+    def run(self, state: State) -> None:
+        self._run(state, 0)
     
-    def run(self, state: State, step: Step) -> Score:
+    def _run(self, state: State, step: Step) -> Score:
             # ループからの離脱
         if step > DRAW_LIMIT: return 0
 
@@ -48,7 +51,7 @@ class TrainDataStrategyFactoryRunner():
         # 再帰
         next_states = state.get_next_states()
         next_state = self.factory.pick_state(state, next_states)
-        score = self.run(next_state, step + 1) * -0.95
+        score = self._run(next_state, step + 1) * -0.95
 
         # フィードバック
         self.factory.data_add(state, score)

--- a/src/domains/shogi/history.py
+++ b/src/domains/shogi/history.py
@@ -2,6 +2,8 @@ from typing import List, Tuple
 from src.consts.domain import Score, SelectionProbability
 from src.domains.abstract.state import State
 from src.domains.abstract.stockable import Stockable
+from src.domains.shogi.visualizers.gif import Gif
+from src.domains.shogi.visualizers.image_visualizer import ImageVisualizer
 from src.domains.shogi.visualizers.string_visualizer import StringVisualizer
 
 class History(Stockable):
@@ -27,3 +29,7 @@ class History(Stockable):
             print(f'probability: {probability}')
             turn = -1 if i % 2 == 1 else 1
             print(f'score: {score * turn}')
+
+    def create_gif(self) -> Gif:
+        images = [ImageVisualizer(state, i % 2 == 1).visualize() for i, (state, _, _) in enumerate(self)]
+        return Gif(images)

--- a/src/domains/shogi/search_tree_node.py
+++ b/src/domains/shogi/search_tree_node.py
@@ -8,7 +8,7 @@ class SearchTreeNode(Stockable):
         self.state = state
         self.score = score
         self.probability = probability
-        self.children: List[Tuple[State, Score, SelectionProbability]] = []
+        self.children: List[SearchTreeNode] = []
 
     def data_add(self, state: State, score: Score, probability: SelectionProbability) -> None:
         self.children.append(SearchTreeNode(state, score, probability))
@@ -17,4 +17,7 @@ class SearchTreeNode(Stockable):
         return self.children
     
     def get_state(self) -> State:
-        return self.state 
+        return self.state
+
+    def get_all(self) -> Tuple[State, Score, SelectionProbability]:
+        return self.state, self.score, self.probability

--- a/src/domains/shogi/search_tree_node.py
+++ b/src/domains/shogi/search_tree_node.py
@@ -1,0 +1,20 @@
+from typing import List, Tuple
+from src.consts.domain import Score, SelectionProbability
+from src.domains.abstract.state import State
+from src.domains.abstract.stockable import Stockable
+
+class SearchTreeNode(Stockable):
+    def __init__(self, state: State, score: Score, probability: SelectionProbability) -> None:
+        self.state = state
+        self.score = score
+        self.probability = probability
+        self.children: List[Tuple[State, Score, SelectionProbability]] = []
+
+    def data_add(self, state: State, score: Score, probability: SelectionProbability) -> None:
+        self.children.append(SearchTreeNode(state, score, probability))
+
+    def get_children(self) -> List['SearchTreeNode']:
+        return self.children
+    
+    def get_state(self) -> State:
+        return self.state 

--- a/src/domains/shogi/visualizers/gif.py
+++ b/src/domains/shogi/visualizers/gif.py
@@ -1,0 +1,27 @@
+import tempfile
+from typing import List
+from PIL import Image as PILImage
+from src.domains.shogi.visualizers.image import Image as MyImage
+
+DURATION = 1000
+
+class Gif():
+    def __init__(self, images: List[MyImage]) -> None:
+        self.images = images
+
+    def show(self) -> None:
+        images = self._get_pil_images()
+        # 一時的なファイルを作成
+        with tempfile.NamedTemporaryFile(suffix=".gif", delete=False) as temp:
+            # 画像の配列からGIFを作成し、一時的なファイルに保存
+            images[0].save(temp.name, save_all=True, append_images=images[1:], duration=DURATION, loop=0)
+            # 一時的なGIFを表示
+            with PILImage.open(temp.name) as img:
+                img.show()
+
+    def save(self, filename: str) -> None:
+        images = self._get_pil_images()
+        images[0].save(filename + '.gif', save_all=True, append_images=images[1:], duration=DURATION, loop=0)
+
+    def _get_pil_images(self) -> List[PILImage.Image]:
+        return [image.get_image() for image in self.images]

--- a/src/domains/shogi/visualizers/graph.py
+++ b/src/domains/shogi/visualizers/graph.py
@@ -1,0 +1,33 @@
+import uuid
+from graphviz import Digraph
+from src.consts.domain import Key
+
+from src.domains.shogi.search_tree_node import SearchTreeNode
+from src.domains.shogi.visualizers.string_visualizer import StringVisualizer
+
+class Graph():
+    def __init__(self, node: SearchTreeNode):
+        self.node = node
+
+    def show(self):
+        # グラフの初期化
+        graph = Digraph('G', filename='sample.gv')
+        self.add_node(graph, self.node, False)
+
+        # グラフのレンダリングと保存
+        graph.render(view=True)
+
+    def add_node(self, graph: Digraph, node: SearchTreeNode, turn: bool) -> Key:
+        state, pre_score, probability = node.get_all()
+        # 先後で反転させる
+        score = pre_score * -1 if turn else pre_score
+        node_key = state.get_unique_key() + str(uuid.uuid4())
+        s = StringVisualizer(state, turn).visualize() + f'\nscore: {score:.2f}\nprobability: {probability:.2f}'
+        graph.node(node_key, s)
+
+        for child in node.get_children():
+            child_key = self.add_node(graph, child, not turn)
+            graph.edge(node_key, child_key)
+
+        return node_key
+

--- a/src/domains/shogi/visualizers/image.py
+++ b/src/domains/shogi/visualizers/image.py
@@ -1,0 +1,14 @@
+from PIL import Image as PILImage
+
+class Image:
+    def __init__(self, image: PILImage.Image):
+        self.image = image
+
+    def show(self) -> None:
+        self.image.show()
+
+    def save(self, filename: str) -> None:
+        self.image.save(filename + '.png')
+
+    def get_image(self) -> PILImage.Image:
+        return self.image

--- a/src/domains/shogi/visualizers/image_visualizer.py
+++ b/src/domains/shogi/visualizers/image_visualizer.py
@@ -5,6 +5,7 @@ from src.domains.shogi.captured import Captured, get_piece_num
 from src.domains.shogi.const import *
 from src.domains.shogi.shogi_state import ShogiState
 from src.domains.shogi.visualizer import Visualizer
+from src.domains.shogi.visualizers.image import Image as MyImage
 
 # 盤面のサイズとセルのサイズを設定します
 board_w_count = 3  # 盤面のサイズ（8x8）
@@ -30,7 +31,7 @@ class ImageVisualizer(Visualizer):
     def captured(self) -> Captured:
         return self.state.captured
     
-    def visualize(self) -> Image:
+    def visualize(self) -> MyImage:
         # 盤面の画像を作成します
         cell_with_padding = cell_size + padding
         board_h_size = board_h_count * cell_size + padding * (board_h_count - 1)
@@ -78,7 +79,7 @@ class ImageVisualizer(Visualizer):
                 x = my_count * (capture_size + padding)
                 image.paste(piece_image, (x, board_h_size + capture_h_size + padding))
                 my_count += 1
-        return image
+        return MyImage(image)
 
     def get_image(self, piece):
         if piece == MY_LION_NUM:

--- a/src/domains/strategy/pick_state_best_strategy.py
+++ b/src/domains/strategy/pick_state_best_strategy.py
@@ -27,6 +27,12 @@ class PickStateBestStrategy(PickStateStrategy):
                 return next_states[i], score, probabilities[i]
         raise 'state not found error'
     
+    def get_all_verbose(self, _original_state: State, next_states: List[State], _data: Dict[Key, List[Score]]) -> List[Tuple[State, Score, SelectionProbability]]:
+        scores = [self._evaluate(state) for state in next_states]
+        probabilities = self._calc_probabilities(scores)
+        result = sorted(zip(next_states, scores, probabilities), key=lambda x: x[1])
+        return result
+    
         # スコアから選出される確率を算出
     def _calc_probabilities(self, scores: List[Score]) -> np.ndarray:
         # softmax関数で算出

--- a/src/domains/strategy/pick_state_randomly_strategy.py
+++ b/src/domains/strategy/pick_state_randomly_strategy.py
@@ -10,3 +10,6 @@ class PickStateRandomlyStrategy(PickStateStrategy):
     
     def pick_state_verbose(self, original_state: State, next_states: List[State], data: Dict[Key, List[Score]]) -> Tuple[State, Score, SelectionProbability]:
         return np.random.choice(next_states), 0, 1 / len(next_states)
+    
+    def get_all_verbose(self, _original_state: State, next_states: List[State], _data: Dict[Key, List[Score]]) -> List[Tuple[State, Score, SelectionProbability]]:
+        return [(state, 0, 1 / len(next_states)) for state in next_states]

--- a/src/domains/strategy/pick_state_softmax_strategy.py
+++ b/src/domains/strategy/pick_state_softmax_strategy.py
@@ -30,6 +30,12 @@ class PickStateSoftmaxStrategy(PickStateStrategy):
 
         return selected_state, score, probability
 
+    def get_all_verbose(self, _original_state: State, next_states: List[State], _data: Dict[Key, List[Score]]) -> List[Tuple[State, Score, SelectionProbability]]:
+        scores = [self._search_score(state.get_unique_key()) for state in next_states]
+        probabilities = self._calc_probabilities(scores)
+        result = sorted(zip(next_states, scores, probabilities), key=lambda x: x[1])
+        return result
+
     # UCBによる補正を加えたスコアを算出
     def _calc_score(self, original_state: State, states: List[State], data: DataDict) -> Score:
         keys = np.array([state.get_unique_key() for state in states])

--- a/src/make_search_tree.py
+++ b/src/make_search_tree.py
@@ -1,0 +1,14 @@
+import argparse
+from src.applications.make_search_tree import make_search_tree
+from src.applications.test_with_model import test_with_model
+
+def get_args() -> str:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filename', type=str)
+
+    args = parser.parse_args()
+    return args.filename
+
+if __name__ == "__main__":
+    filename = get_args()
+    make_search_tree(filename)


### PR DESCRIPTION
# ベンチマークのリファクタ
- ベンチマークのResultに回答と正解を別で保存した
- ベンチマーク実行結果のgif表示機能の追加
- 依存関係が逆転していた箇所を修正

# 図の描画部分
- gifの描画を追加
- 探索木の作成機能の追加
- graphvizによるnodeの探索木の描画機能の追加